### PR TITLE
Money class expects an str instead of a CurrencyCodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ pip install moneymoney
 from moneymoney.currency_codes import CurrencyCodes
 from moneymoney.money import Money
 
-quantity = Money(amount=1000, currency_code=CurrencyCodes.EUR)
+# using a string as currency code
+quantity = Money(amount=1000, currency_code="EUR")
+
+# using currency codes from this package
+quantity_two = Money(amount=1000, currency_code=CurrencyCodes.EUR)
 ```
 
 ## Contributing

--- a/moneymoney/money.py
+++ b/moneymoney/money.py
@@ -16,7 +16,7 @@ class Money:
     to be of the same currency.
     """
 
-    def __init__(self, currency_code: CurrencyCodes, amount: float = 0.0):
+    def __init__(self, currency_code: str, amount: float = 0.0):
         if currency_code is None:
             raise CurrencyCodeIsNoneException()
         self._amount = amount

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -11,6 +11,12 @@ def test_can_create_money():
     assert money.currency_code == currency_code
 
 
+def test_can_create_money_with_str_as_currency_code():
+    money = Money(currency_code="GBP")
+    assert money.amount == 0.0
+    assert money.currency_code == "GBP"
+
+
 def test_can_print_money():
     currency_code = Faker().currency_code()
     money = Money(currency_code=currency_code)


### PR DESCRIPTION
## What?
Since CurrencyCodes inherits from `str`, `Money` can be built from `str` too. Making it easier to be used everywhere.

## Checklist
- [x] Label added to the PR
- [x] PR up to date with default branch
- [x] All checks are green
