### PR TITLE
Able to operate with Money of same currency, but in either lowercase or uppercase

### DIFF
--- a/moneymoney/money.py
+++ b/moneymoney/money.py
@@ -32,7 +32,7 @@ class Money:
 
     def __add__(self, other):
         if isinstance(other, Money):
-            if other.currency_code != self.currency_code:
+            if other.currency_code.lower() != self.currency_code.lower():
                 raise CurrencyIsNotTheSameException()
             other = other.amount
         amount = self.amount + other
@@ -40,7 +40,7 @@ class Money:
 
     def __sub__(self, other):
         if isinstance(other, Money):
-            if other.currency_code != self.currency_code:
+            if other.currency_code.lower() != self.currency_code.lower():
                 raise CurrencyIsNotTheSameException()
             other = other.amount
         amount = self.amount - other
@@ -48,7 +48,7 @@ class Money:
 
     def __eq__(self, other):
         if isinstance(other, Money):
-            return (self._amount == other.amount) and (self._currency_code == other.currency_code)
+            return (self._amount == other.amount) and (self._currency_code.lower() == other.currency_code.lower())
         return False
 
     def __str__(self):

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -30,6 +30,12 @@ def test_money_are_equal():
     assert money_one == money_two
 
 
+def test_money_are_equal_for_same_currency_in_uppercase_and_lowercase():
+    money_one = Money(currency_code="GBP", amount=1.0)
+    money_two = Money(currency_code="gbp", amount=1.0)
+    assert money_one == money_two
+
+
 def test_money_are_not_equal():
     currency_code_one = Faker().currency_code()
     currency_code_two = Faker().currency_code()
@@ -52,6 +58,13 @@ def test_can_add_moneys_of_same_currency():
     assert money_three.currency_code == currency_code
 
 
+def test_can_add_moneys_of_same_currency_different_case_currency_code():
+    money_one = Money(currency_code="GBP", amount=1.0)
+    money_two = Money(currency_code="gbp", amount=3.0)
+    money_three = money_one + money_two
+    assert money_three.amount == 4.0
+
+
 def test_cannot_add_moneys_of_different_currency():
     currency_code_one = Faker().currency_code()
     currency_code_two = Faker().currency_code()
@@ -68,6 +81,13 @@ def test_can_sub_moneys_of_same_currency():
     money_three = money_one - money_two
     assert money_three.amount == -2.0
     assert money_three.currency_code == currency_code
+
+
+def test_can_sub_moneys_of_same_currency_different_case_currency_code():
+    money_one = Money(currency_code="GBP", amount=1.0)
+    money_two = Money(currency_code="gbp", amount=3.0)
+    money_three = money_one - money_two
+    assert money_three.amount == -2.0
 
 
 def test_cannot_sub_moneys_of_different_currency():


### PR DESCRIPTION
## What?
Money in either GBP or gbp should be able to operate.
This allows to add, sub and compare Money of same currency code but in either uppercase or lowercase

## Checklist
- [x] Label added to the PR
- [x] PR up to date with default branch
- [x] All checks are green
